### PR TITLE
Fix terminal stderr regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Jefvantongerloo.aos release notes
 
-## [0.2.0] - Unreleased
+## [0.1.1] - Unreleased
 
 ### Added
 
-- Action plugin `net_get` and `net_put` - tested and approved working with sftp
+- action plugin `net_get` and `net_put` - tested and approved working with sftp
+
+### Fixed
+
+- terminal stderr `ERROR` regex in `terminal.aos` not matching correctly
 
 ## [0.1.0] - Unreleased
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,15 +1,15 @@
 namespace: "jefvantongerloo"
 name: "aos"
-version: 0.1.0
+version: "0.1.1"
 readme: "README.md"
 authors:
   - "Jef Vantongerloo <jefvantongerloo@gmail.com>"
 description: "Ansible collection to support Alcatel-Lucent Enterprise OmniSwitch devices (aos6 & aos8) "
 license:
-- "CC-BY-NC-ND-4.0"
+  - "CC-BY-NC-ND-4.0"
 license_file: ""
 tags:
-  - networking 
+  - networking
   - ale
   - alcatel
   - aos

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.9.10" # min for netcommon >3.0 support
+requires_ansible: ">=2.10.10" # min for netcommon >3.0 support

--- a/plugins/terminal/aos.py
+++ b/plugins/terminal/aos.py
@@ -53,8 +53,8 @@ class TerminalModule(TerminalBase):
 
     #: compiled bytes regular expressions as stderr
     terminal_stderr_re = [
-        re.compile(rb"Authentication failure", re.IGNORECASE),
-        re.compile(rb"[\r\n]ERROR:\s*.*[\r\n]+", re.IGNORECASE),
+        re.compile(rb"[\n|\r]+Authentication failure[\n|\r]+", re.IGNORECASE),
+        re.compile(rb"\^[\n|\r]+ERROR: Invalid entry: \".*\"", re.IGNORECASE),
     ]
 
     #: compiled bytes regular expressions to remove ANSI codes


### PR DESCRIPTION
Correct output was redirected to stderr because of the wrong terminal stderr ´ERROR:´ output regex pattern.